### PR TITLE
Allow running `op -w` without code to see all codes and commands

### DIFF
--- a/op
+++ b/op
@@ -174,7 +174,8 @@ opcode_context() {
 
   what_command() {
     if [[ -z "$CODE" ]]; then
-      for CODE in $(list_codes);  do
+      local commands=( $(list_codes) )
+      for CODE in "${commands[@]}"; do
         find_command
         echo "$CODE: $COMMAND"
       done

--- a/op
+++ b/op
@@ -174,11 +174,16 @@ opcode_context() {
 
   what_command() {
     if [[ -z "$CODE" ]]; then
-      local commands=( $(list_codes) )
-      for CODE in "${commands[@]}"; do
-        find_command
-        echo "$CODE: $COMMAND"
-      done
+      regex="^([^#][^:]*):\s*(.+)$"
+
+      # shellcheck disable=SC2162
+      while IFS= read line || [ -n "$line" ]; do
+        if [[ $line =~ $regex ]]; then
+          printf "%s: %s\n" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+        fi
+      done < "$CONFIG_FILE"
+      printf "\n"
+
     else
       find_command
       if [[ -n $COMMAND ]]; then
@@ -188,6 +193,7 @@ opcode_context() {
         echo "Code not found: $CODE"
         exit 1
       fi
+
     fi
   }
 

--- a/op
+++ b/op
@@ -25,9 +25,9 @@ opcode_context() {
     if $LONG_USAGE; then
       printf "    Show the config file (%s)\n\n" "$CONFIG_FILE"
     fi
-    printf "  op -w, --what CODE\n"
+    printf "  op -w, --what [CODE]\n"
     if $LONG_USAGE; then
-      printf "    Show the command for a given code\n\n"
+      printf "    Show the command for a given code or all codes\n\n"
     fi
     printf "  op -e, --edit\n"
     if $LONG_USAGE; then
@@ -132,6 +132,7 @@ opcode_context() {
 
     echo "${output[@]}"
   }
+  
   list_codes() {
     need_config
     regex="^([^#][^:]*)"
@@ -172,13 +173,20 @@ opcode_context() {
   }
 
   what_command() {
-    find_command
-    if [[ -n $COMMAND ]]; then
-      # shellcheck disable=SC2086
-      echo $COMMAND
+    if [[ -z "$CODE" ]]; then
+      for CODE in $(list_codes);  do
+        find_command
+        echo "$CODE: $COMMAND"
+      done
     else
-      echo "Code not found: $CODE"
-      exit 1
+      find_command
+      if [[ -n $COMMAND ]]; then
+        # shellcheck disable=SC2086
+        echo $COMMAND
+      else
+        echo "Code not found: $CODE"
+        exit 1
+      fi
     fi
   }
 

--- a/op
+++ b/op
@@ -63,8 +63,8 @@ opcode_context() {
       exit 1
     fi
 
-    exact="^${CODE}:\s*(.+)$"
-    fuzzy="^${CODE}[^\:]*:\s*(.+)$"
+    exact="^${CODE}:[[:space:]]*(.+)$"
+    fuzzy="^${CODE}[^\:]*:[[:space:]]*(.+)$"
 
     # shellcheck disable=SC2162
     while IFS= read line || [ -n "$line" ]; do
@@ -174,7 +174,7 @@ opcode_context() {
 
   what_command() {
     if [[ -z "$CODE" ]]; then
-      regex="^([^#][^:]*):\s*(.+)$"
+      regex="^([^#][^:]*):[[:space:]]*(.+)$"
 
       # shellcheck disable=SC2162
       while IFS= read line || [ -n "$line" ]; do
@@ -182,7 +182,6 @@ opcode_context() {
           printf "%s: %s\n" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
         fi
       done < "$CONFIG_FILE"
-      printf "\n"
 
     else
       find_command

--- a/test/fixtures/basic/approvals/op_w
+++ b/test/fixtures/basic/approvals/op_w
@@ -1,11 +1,2 @@
-Invalid operation
-Usage:
-  op CODE [ARGS]
-  op ?
-  op -l, --list
-  op -s, --show
-  op -w, --what CODE
-  op -e, --edit
-  op -a, --add CODE COMMAND...
-  op -h, --help
-  op -v, --version
+hello: echo world
+who: whoami

--- a/test/fixtures/empty-dir/approvals/op
+++ b/test/fixtures/empty-dir/approvals/op
@@ -3,7 +3,7 @@ Usage:
   op ?
   op -l, --list
   op -s, --show
-  op -w, --what CODE
+  op -w, --what [CODE]
   op -e, --edit
   op -a, --add CODE COMMAND...
   op -h, --help

--- a/test/fixtures/empty-dir/approvals/op_add
+++ b/test/fixtures/empty-dir/approvals/op_add
@@ -4,7 +4,7 @@ Usage:
   op ?
   op -l, --list
   op -s, --show
-  op -w, --what CODE
+  op -w, --what [CODE]
   op -e, --edit
   op -a, --add CODE COMMAND...
   op -h, --help

--- a/test/fixtures/empty-dir/approvals/op_help
+++ b/test/fixtures/empty-dir/approvals/op_help
@@ -14,8 +14,8 @@ Usage:
   op -s, --show
     Show the config file (op.conf)
 
-  op -w, --what CODE
-    Show the command for a given code
+  op -w, --what [CODE]
+    Show the command for a given code or all codes
 
   op -e, --edit
     Open the config file for editing

--- a/test/what_spec.sh
+++ b/test/what_spec.sh
@@ -20,6 +20,5 @@ describe "op -w <code that does not exist>"
 
 describe "op -w"
   cd ./fixtures/basic
-  approve "op -w" || return 0
-  expect_exit_code 1
+  approve "op -w"
   cd ../../


### PR DESCRIPTION
Change usage pattern `op -w CODE` to `op -w [CODE]` to allow showing all `code: command` pairs.

cc #24