### PR TITLE
[BREAKING] Multiline commands are now joined with a newline + arguments (`$@`) are no longer attached automatically to the command

### DIFF
--- a/op
+++ b/op
@@ -326,10 +326,13 @@ opcode_context() {
   }
 
   # color functions are here even if not used directly to allow using in op.conf
-  green() { printf "\e[32m%b\e[0m\n" "$*"; }
-  red() { printf "\e[31m%b\e[0m\n" "$*"; }
-  blue() { printf "\e[34m%b\e[0m\n" "$*"; }
   bold() { printf "\e[1m%b\e[0m\n" "$*"; }
+  red() { printf "\e[31m%b\e[0m\n" "$*"; }
+  green() { printf "\e[32m%b\e[0m\n" "$*"; }
+  yellow() { printf "\e[33m%b\e[0m\n" "$*"; }
+  blue() { printf "\e[34m%b\e[0m\n" "$*"; }
+  magenta() { printf "\e[35m%b\e[0m\n" "$*"; }
+  cyan() { printf "\e[36m%b\e[0m\n" "$*"; }
 
   opcode_initialize() {
     VERSION="1.0.0"

--- a/op
+++ b/op
@@ -73,84 +73,64 @@ opcode_context() {
 
   find_command() {
     need_config
+    code="$1"
 
-    if [[ -z $CODE ]]; then
-      echo "Invalid operation"
-      usage
-      exit 1
+    result=$(get_script "$code" "exact")
+    if [[ -z $result ]]; then
+      result=$(get_script "$code" "fuzzy")
     fi
 
-    COMMAND=$(get_command_from_file "exact")
-    if [[ -z $COMMAND ]]; then
-      COMMAND=$(get_command_from_file "fuzzy")
-    fi
+    echo "$result"
   }
 
-  get_command_from_file() {
-    local pattern
+  get_script() {
+    local code="$1"
+    local mode="$2"
+    local -a script=()
+    local strict_pattern="^${code}:[[:space:]]*(.*)$"
+    local fuzzy_pattern="^${code}[^:]*:[[:space:]]*(.*)$"
+    local found=0
 
-    if [[ $1 == "fuzzy" ]]; then
-      pattern="^${CODE}[^:]*:[[:space:]]*(.*)$"
+    if [[ $mode == "fuzzy" ]]; then
+      pattern="$fuzzy_pattern"
     else
-      pattern="^${CODE}:[[:space:]]*(.*)$"
+      pattern="$strict_pattern"
     fi
 
-    local command=""
-    local collect_command=false
-    local temp_line=""
-
     while IFS= read -r line || [[ -n $line ]]; do
-      if [[ -n "$temp_line" ]]; then
-        trimmed_line=${line#"${line%%[![:space:]]*}"}
-        temp_line="${temp_line%\\}$trimmed_line"
-        if [[ "$line" =~ \\$ ]]; then
-          continue
-        else
-          line="$temp_line"
-          temp_line=""
-        fi
-      fi
-
-      if [[ "$line" =~ \\$ ]]; then
-        trimmed_line=${line#"${line%%[![:space:]]*}"}
-        temp_line="${temp_line%\\}$trimmed_line"
-        continue
-      fi
-
-      if $collect_command; then
-        if [[ -z "${line}" || ! "${line}" =~ ^[[:space:]]+ ]]; then
+      if [[ $line =~ $pattern ]]; then
+        if [[ $found == 1 ]]; then
           break
         fi
 
-        trimmed_line="${line#"${line%%[![:space:]]*}"}"
-        command="${command:+$command && }$trimmed_line"
-      else
-        if [[ $line =~ $pattern ]]; then
-          command="${BASH_REMATCH[1]}"
-          if [[ -n $command ]]; then
-            break
-          fi
-
-          collect_command=true
+        found=1
+        line="${BASH_REMATCH[1]}"
+        if [[ -n $line ]]; then
+          script+=("$line")
+        fi
+      elif [[ $found == 1 ]]; then
+        if [[ $line =~ ^[[:space:]]+(.+)$ ]]; then
+          script+=("${BASH_REMATCH[1]}")
+        else
+          break
         fi
       fi
     done <"$CONFIG_FILE"
 
-    echo "$command"
+    printf "%s\n" "${script[@]}"
   }
 
   run_command() {
-    find_command
-    if [[ -n $COMMAND ]]; then
-      if [[ $COMMAND =~ \$ ]]; then
-        eval "$COMMAND"
-      else
-        # shellcheck disable=SC2294
-        eval "$COMMAND" "$@"
-      fi
-    else
-      abort "Code not found: $CODE"
+    local command
+    local code="$1"
+    shift # so that $@ is properly available to the user script
+
+    command=$(find_command "$code")
+    if [[ -z $command ]]; then
+      abort "Code not found: $code"
     fi
+
+    eval "$command"
   }
 
   add_command() {
@@ -190,7 +170,7 @@ opcode_context() {
     break_regex="^[[:space:]]*private[[:space:]]*$"
 
     # shellcheck disable=SC2162
-    while IFS= read line || [ -n "$line" ]; do
+    while IFS= read line || [[ -n "$line" ]]; do
       if [[ $line =~ $regex ]]; then
         printf "%s   " "${BASH_REMATCH[1]}"
       elif [[ $line =~ $break_regex ]]; then
@@ -211,7 +191,7 @@ opcode_context() {
     echo "Usage: op COMMAND [ARGS]"
 
     # shellcheck disable=SC2162
-    while IFS= read line || [ -n "$line" ]; do
+    while IFS= read line || [[ -n "$line" ]]; do
       if [[ $line =~ $break_regex ]]; then
         break
       fi
@@ -246,28 +226,18 @@ opcode_context() {
   }
 
   what_command() {
-    if [[ -z "$CODE" ]]; then
-      regex="^([^#:]*):[[:space:]]*(.+)$"
-      break_regex="^[[:space:]]*private[[:space:]]*$"
+    local code="$1"
+    local script
 
-      # shellcheck disable=SC2162
-      while IFS= read line || [ -n "$line" ]; do
-        if [[ $line =~ $regex ]]; then
-          printf "%s: %s\n" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
-        elif [[ $line =~ $break_regex ]]; then
-          break
-        fi
-      done <"$CONFIG_FILE"
+    if [[ -z $code ]]; then
+      abort 'Usage: op --what CODE'
+    fi
 
+    script=$(get_script "$code")
+    if [[ -n $script ]]; then
+      echo "$script"
     else
-      find_command
-      if [[ -n $COMMAND ]]; then
-        # shellcheck disable=SC2086
-        echo $COMMAND
-      else
-        abort "Code not found: $CODE"
-      fi
-
+      abort "Code not found: $code"
     fi
   }
 
@@ -304,24 +274,13 @@ opcode_context() {
       \? | -i | --info) list_codes_extended ;;
       -l | --list) list_codes ;;
       -s | --show) show_config ;;
-      -w | --what)
-        shift
-        CODE=$1
-        what_command
-        ;;
+      -w | --what) what_command "$2" ;;
       -e | --edit) edit_config ;;
-      -a | --add)
-        shift
-        add_command "$@"
-        ;;
+      -a | --add) add_command "${@:2}" ;;
       -h | --help) usage 'long' ;;
       -v | --version) echo "$VERSION" ;;
       --completion) send_completion ;;
-      *)
-        CODE=$1
-        shift
-        run_command "$@"
-        ;;
+      *) run_command "$@" ;;
     esac
   }
 

--- a/test/fixtures/advanced/op.conf
+++ b/test/fixtures/advanced/op.conf
@@ -3,5 +3,5 @@
 
 # Also note this file does NOT end with a newline, and the command reverse
 # should still be read properly
-greet: echo Hello
-reverse: echo $2 and $1
+greet: echo Hello "$@"
+reverse: echo "$2" and "$1"

--- a/test/fixtures/basic/approvals/op_w
+++ b/test/fixtures/basic/approvals/op_w
@@ -1,2 +1,1 @@
-hello: echo world
-who: whoami
+Usage: op --what CODE

--- a/test/fixtures/multiline/approvals/op_
+++ b/test/fixtures/multiline/approvals/op_
@@ -1,7 +1,7 @@
 Usage: op COMMAND [ARGS]
   [1mone[0m
   [1mmulti[0m
-    these lines will be joined with &&
+    these lines will be joined with a newline
 
   [1mconcat[0m
     these lines will be joined without any glue

--- a/test/fixtures/multiline/approvals/op_w_concat
+++ b/test/fixtures/multiline/approvals/op_w_concat
@@ -1,1 +1,4 @@
-echo who ordered this pizza
+echo who \
+ordered \
+this \
+pizza

--- a/test/fixtures/multiline/approvals/op_w_multi
+++ b/test/fixtures/multiline/approvals/op_w_multi
@@ -1,1 +1,3 @@
-echo one : two && echo three && echo four
+echo one : two
+echo three
+echo four

--- a/test/fixtures/multiline/op.conf
+++ b/test/fixtures/multiline/op.conf
@@ -4,7 +4,7 @@ multi:
   echo one : two
   echo three
   echo four
-#? these lines will be joined with &&
+#? these lines will be joined with a newline
 
 concat: echo who \
   ordered \

--- a/test/fixtures/one-char/approvals/op_w
+++ b/test/fixtures/one-char/approvals/op_w
@@ -1,2 +1,0 @@
-1: echo 1
-a: echo a

--- a/test/fixtures/private/approvals/op_w
+++ b/test/fixtures/private/approvals/op_w
@@ -1,2 +1,0 @@
-one: echo one
-two: op three

--- a/test/what_spec.sh
+++ b/test/what_spec.sh
@@ -2,18 +2,8 @@
 source 'approvals.bash'
 
 describe "op --what"
-  context "without additional arguments"
+  context "without command code"
     cd ./fixtures/basic
-    approve "op -w"
-    cd ../../
-
-  context "without additional arguments when private commands exist"
-    cd ./fixtures/private
-    approve "op -w"
-    cd ../../
-
-  describe "without additional arguments when single char commands exist"
-    cd ./fixtures/one-char
     approve "op -w"
     cd ../../
 


### PR DESCRIPTION
## ⚠️ This is a breaking change.

### Multiline commands are simpler to use

In previous versions, multiline commands like this would have been merged with `&&`:

```
command:
  echo "one"
  echo "two"
```

In this PR, they are joined with a newline, to allow for a wider use case spectrum.

### Arguments are no longer attached automatically

In previous versions, a configuration file like this:

```
greet: echo Hello
````

would have yielded "Hello World" when executed as `op greet World`.

Now, due to the possibility that this is not necessarily desired (in multiline commands), you need to use `argv` variables - `$@`, `$1`, `$2` etc - wherever you need them. So in order for the above configuration to work as before, it needs to be written as:

```
greet: echo "Hello $@"
# or 
greet: echo "Hello $1"
````
