### PR TITLE
Fix typo in execute_spec.sh

### DIFF
--- a/test/execute_spec.sh
+++ b/test/execute_spec.sh
@@ -7,7 +7,7 @@ describe "op <command>"
     approve "op hello"
     cd ../../
 
-  context "when the approved command exits wiuth non zero"
+  context "when the approved command exits with non zero"
     it "continues execution and stores exit code"
       cd ./fixtures/basic
       approve "op nocommand"


### PR DESCRIPTION
## Summary
- correct spelling of "with" in execute_spec

## Testing
- `shellcheck op setup` *(fails: command not found)*
- `test/approve`

------
https://chatgpt.com/codex/tasks/task_e_6874d91aa23c832c9010c87321e40ea5